### PR TITLE
fix invoke parameter

### DIFF
--- a/docs/sapnwrfc.stubs.php
+++ b/docs/sapnwrfc.stubs.php
@@ -192,7 +192,7 @@ class RemoteFunction
      *
      * @throws FunctionCallException if any error occurs during execution.
      */
-    public function invoke(array $parameters, array $options = [])
+    public function invoke(array $parameters = [], array $options = [])
     {
     }
 


### PR DESCRIPTION
In the documentation I can read "we can simply call invoke() without parameters", we need default parameter than.