### PR TITLE
feat(build): add automated Windows build script with multi-variant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,10 @@ Makefile.objects
 acinclude.m4
 aclocal.m4
 autom4te.cache/
-build/
+build/output/
+build/php/
+build/sap/
+build/workspace/
 config.guess
 config.h
 config.h.in
@@ -43,3 +46,11 @@ todo.txt
 .gdbinit
 .vscode
 *.o
+
+# Windows build output (nmake)
+x64/
+x86/
+configure.bat
+config.nice.bat
+configure.js
+*.log

--- a/build/build-windows.md
+++ b/build/build-windows.md
@@ -1,0 +1,181 @@
+# Building php-sapnwrfc on Windows
+
+## Prerequisites
+
+### 1. Visual Studio 2026 with the required MSVC toolsets
+
+Install **Visual Studio 2026** with the **"Desktop development with C++"** workload.
+VS 2026 ships with the v144 (vs18) toolset, but the current PHP Windows binaries are compiled
+with older toolsets. Both must be added as individual components:
+
+| PHP version | Zip toolset | Required MSVC component |
+|-------------|-------------|-------------------------|
+| 8.2, 8.3 | vs16 | **MSVC v142 – VS 2019 C++ x64/x86 Build Tools (v14.29–16.11)** |
+| 8.4, 8.5 | vs17 | **MSVC v143 – VS 2022 C++ x64/x86 Build Tools** |
+
+Install both via **VS Installer → Modify → Individual Components** and search for "MSVC v142"
+and "MSVC v143".
+
+The build script auto-detects which toolset each PHP zip requires and selects the correct compiler
+via `vcvarsall.bat -vcvars_ver`. If a required toolset is not installed it exits with a clear
+error and installation instructions.
+
+Download VS: https://visualstudio.microsoft.com/downloads/
+
+### 2. PHP zips (binary + devel) and PHP SDK
+
+Place the following files in the `build\php\` folder.
+
+**PHP 8.2 and 8.3** (toolset vs16):
+
+| File | Purpose |
+|------|---------|
+| `php-{ver}-Win32-vs16-x64.zip` | TS binary |
+| `php-{ver}-nts-Win32-vs16-x64.zip` | NTS binary |
+| `php-devel-pack-{ver}-Win32-vs16-x64.zip` | TS devel (provides `phpize` + headers) |
+| `php-devel-pack-{ver}-nts-Win32-vs16-x64.zip` | NTS devel |
+
+**PHP 8.4 and 8.5** (toolset vs17):
+
+| File | Purpose |
+|------|---------|
+| `php-{ver}-Win32-vs17-x64.zip` | TS binary |
+| `php-{ver}-nts-Win32-vs17-x64.zip` | NTS binary |
+| `php-devel-pack-{ver}-Win32-vs17-x64.zip` | TS devel |
+| `php-devel-pack-{ver}-nts-Win32-vs17-x64.zip` | NTS devel |
+
+**PHP SDK binary tools** (one file, any PHP version):
+
+| File | Purpose |
+|------|---------|
+| `php-sdk-binary-tools-*.zip` | Build environment setup scripts |
+
+Download PHP zips from https://windows.php.net/download/ — choose the **zip** packages (not the
+installer). Download the PHP SDK zip from https://github.com/php/php-sdk-binary-tools/releases.
+
+### 3. SAP NW RFC SDK
+
+Place the SAP NW RFC SDK zip (e.g. `nwrfc750P_18-70002755.zip`) in the `build\sap\` folder.
+Obtain it from the SAP Software Downloads portal (requires SAP account).
+
+Expected layout inside the zip:
+
+```
+nwrfcsdk\
+  include\   ← header files
+  lib\        ← sapnwrfc.lib, libsapucum.lib, *.dll
+```
+
+---
+
+## Running the build
+
+Open **PowerShell** and run from the `build\` directory:
+
+```powershell
+cd path\to\php-sapnwrfc\build
+.\build-windows.ps1
+```
+
+The script automatically finds every PHP zip in `.\php\` and builds the extension for each variant.
+
+### Optional parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `-WorkspaceDir` | Where extracted PHP binaries, devel packs, PHP SDK, and SAP SDK land | `.\workspace` |
+| `-OutputDir` | Where built DLLs are collected | `.\output` |
+| `-Toolset` | Override the MSVC toolset for all variants (e.g. `vs17`, `vs18`) | auto-detected from zip name |
+| `-RunTests` | Run `nmake test` after each build | — |
+
+Examples:
+
+```powershell
+# Build all variants (normal case)
+.\build-windows.ps1
+
+# Custom workspace and output directories, run tests after each build
+.\build-windows.ps1 -WorkspaceDir "D:\build" -OutputDir "D:\dist" -RunTests
+
+# Force a specific compiler toolset
+.\build-windows.ps1 -Toolset vs17
+```
+
+### Script execution policy
+
+If you get a script-execution error, allow local scripts for the current session:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+---
+
+## What the script does
+
+1. Reads the extension version from `php_sapnwrfc.h`.
+2. Scans `.\php\*.zip` to discover PHP variants (TS / NTS, version, toolset, arch).
+3. Detects the installed Visual Studio via `vswhere`.
+4. Extracts the SAP NW RFC SDK from `.\sap\*.zip` into `workspace\nwrfcsdk` and reads its version from `sapnwrfc.dll`.
+5. Extracts the PHP SDK binary tools from `.\php\php-sdk-binary-tools-*.zip` into `workspace\php-sdk`.
+6. For **each** PHP variant:
+   a. Extracts the PHP binary zip to `workspace\php-{ver}-{ts|nts}-{arch}`.
+   b. Extracts the matching devel zip to `workspace\php-devel-pack-{ver}[-nts]-Win32-{toolset}-{arch}`.
+   c. Sets up the correct MSVC environment (via `phpsdk-{toolset}-{arch}.bat` for same-toolset builds, or `vcvarsall.bat -vcvars_ver` for cross-toolset builds) and runs:
+      ```
+      phpize
+      configure --with-prefix=<phpDir> --with-sapnwrfc=<nwrfcsdkDir>
+      nmake
+      ```
+   d. Copies the built DLL to `.\output\` with a versioned filename.
+7. Prints a summary of all built DLLs.
+
+---
+
+## Output
+
+All DLLs land directly in `build\output\` with a filename that encodes every relevant version:
+
+```
+php_sapnwrfc-{ext_ver}+php.{php_ver}-{ts|nts}-{toolset}-{arch}.sdk.{sdk_ver}.dll
+```
+
+Example:
+
+```
+php_sapnwrfc-2.1.0+php.8.3.31-ts-vs16-x64.sdk.7500.0.13.dll
+php_sapnwrfc-2.1.0+php.8.3.31-nts-vs16-x64.sdk.7500.0.13.dll
+```
+
+---
+
+## Installing the built extension
+
+1. Copy the appropriate DLL to your PHP `ext\` directory.
+2. Add the following to `php.ini`:
+   ```ini
+   extension=sapnwrfc
+   ```
+3. Add the SAP NW RFC SDK `lib\` directory to the system `PATH` so PHP can load the SAP DLLs at runtime.
+
+Verify with:
+
+```
+php -m | findstr sapnwrfc
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| No PHP zips found | Place binary zips in `build\php\` with the expected naming pattern |
+| No SAP SDK zip found | Place the SAP zip in `build\sap\` |
+| Devel package not found | Place the matching `php-devel-pack-{ver}[-nts]-Win32-{toolset}-x64.zip` in `build\php\` |
+| PHP SDK zip not found | Place `php-sdk-binary-tools-*.zip` in `build\php\` |
+| `phpize` not found | Devel package not on PATH — check that extraction succeeded in `workspace\` |
+| `configure` fails: SDK not found | Verify extracted SDK has `include\` and `lib\` under `workspace\nwrfcsdk` |
+| `phpsdk-vs1X-x64.bat` not found | Toolset mismatch — use `-Toolset` to select an available toolset |
+| MSVC toolset not found | Install the required v142/v143 component via VS Installer (see Prerequisites) |
+| Tests fail: module not loaded | Ensure `workspace\nwrfcsdk\lib` is on `PATH` (`-RunTests` adds it automatically) |

--- a/build/build-windows.ps1
+++ b/build/build-windows.ps1
@@ -1,0 +1,467 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Builds the php-sapnwrfc extension on Windows for every PHP variant found in .\php\.
+
+.DESCRIPTION
+    Picks up PHP binary zips from .\php\ (TS and/or NTS), the matching devel packs,
+    the PHP SDK binary-tools zip, and the SAP NW RFC SDK zip - all from local disk,
+    no internet access required. Extracts everything into WorkspaceDir and builds the
+    extension for each variant using the correct MSVC toolset.
+
+    --- Required files ---
+
+    Place in .\php\
+      TS binary : php-{ver}-Win32-{toolset}-{arch}.zip
+      NTS binary: php-{ver}-nts-Win32-{toolset}-{arch}.zip
+      Devel pack: php-devel-pack-{ver}[-nts]-Win32-{toolset}-{arch}.zip
+      PHP SDK   : php-sdk-binary-tools-*.zip
+                  (download from github.com/php/php-sdk-binary-tools/releases)
+
+    Place in .\sap\
+      SAP NW RFC SDK: any single *.zip
+                      (the zip must contain a top-level "nwrfcsdk" folder)
+
+    --- Toolset handling ---
+
+    The MSVC toolset (vs17, vs18, ...) is read from the PHP zip filenames and used for
+    both devel pack lookup and compiler selection. When the installed Visual Studio is a
+    different generation than the zip toolset (e.g. VS 2026 with vs17 PHP zips), the
+    script automatically selects the matching older MSVC toolset via vcvarsall
+    -vcvars_ver. This requires the older toolset to be installed as a VS component.
+
+    Toolset generations and their MSVC version ranges:
+      vs16 = VS 2019, MSVC 14.20-14.29
+      vs17 = VS 2022, MSVC 14.30-14.43
+      vs18 = VS 2026, MSVC 14.44+
+
+    If the required toolset is not installed the script exits with a clear error and
+    installation instructions. Use -Toolset only as an explicit override.
+
+    --- Visual Studio setup ---
+
+    The installed VS is detected automatically via vswhere at startup. When the zip
+    toolset matches the installed VS, the standard phpsdk bat is used to set up the
+    build environment. When they differ, vcvarsall.bat is called directly with the
+    appropriate -vcvars_ver value so the correct compiler is selected.
+
+    Note: vcvarsall.bat may print a harmless "vswhere.exe not found" warning to stderr
+    when vswhere is not on PATH - this does not affect the build.
+
+.PARAMETER WorkspaceDir
+    Directory for extracted PHP binaries, devel packs, PHP SDK, and SAP NW RFC SDK.
+    Default: ".\workspace" (subfolder next to this script).
+    Re-running the script skips already-extracted content.
+
+.PARAMETER OutputDir
+    Directory where built DLLs are collected after each successful build.
+    Default: ".\output" (subfolder next to this script).
+    All DLLs land directly in this directory — no per-variant subfolders.
+
+.PARAMETER Toolset
+    Override the MSVC toolset for all variants (e.g. "vs17", "vs18").
+    Overrides only the compiler selection; devel pack lookup still uses the zip toolset.
+    Normally not needed - the script auto-selects the correct toolset.
+
+.PARAMETER RunTests
+    Run "nmake test" after each successful build.
+
+.EXAMPLE
+    .\build-windows.ps1
+    Build all variants. Toolset is read from zip filenames; cross-toolset builds
+    (e.g. vs17 zips on a VS 2026 host) are handled automatically.
+    DLLs are collected in .\output\.
+
+.EXAMPLE
+    .\build-windows.ps1 -Toolset vs18
+    Force vs18 compiler for all variants regardless of zip toolset labels.
+
+.EXAMPLE
+    .\build-windows.ps1 -WorkspaceDir "D:\build" -OutputDir "D:\dist" -RunTests
+    Build into a custom workspace, collect DLLs into D:\dist\, and run tests after each build.
+#>
+[CmdletBinding()]
+param(
+    [string]$WorkspaceDir = "",
+    [string]$OutputDir    = "",
+    [string]$Toolset      = "",          # e.g. "vs18" — overrides zip-detected value
+    [switch]$RunTests
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Step([string]$msg) { Write-Host "`n==> $msg" -ForegroundColor Cyan }
+function Fail([string]$msg) { Write-Error $msg -ErrorAction Continue; exit 1 }
+
+# Returns [PSCustomObject]@{Toolset="vsXX"; InstallPath="..."} or $null
+function Get-VsToolset {
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path $vswhere)) { return $null }
+    $ver  = & $vswhere -latest -property installationVersion 2>$null
+    $path = & $vswhere -latest -property installationPath 2>$null
+    if (-not $ver) { return $null }
+    $major = [int]($ver -split '\.')[0]
+    return [PSCustomObject]@{ Toolset = "vs$major"; InstallPath = $path }
+}
+
+$ExtSourceDir = (Resolve-Path "$PSScriptRoot\..").Path
+if (-not $WorkspaceDir) { $WorkspaceDir = Join-Path $PSScriptRoot "workspace" }
+if (-not $OutputDir)    { $OutputDir    = Join-Path $PSScriptRoot "output" }
+$PhpSdkDir    = Join-Path $WorkspaceDir "php-sdk"
+
+# Read extension version from php_sapnwrfc.h
+$extVersion = $null
+$versionHeader = Join-Path $ExtSourceDir "php_sapnwrfc.h"
+if (Test-Path $versionHeader) {
+    $headerContent = Get-Content $versionHeader -Raw
+    if ($headerContent -match '#define\s+PHP_SAPNWRFC_VERSION\s+"([^"]+)"') {
+        $extVersion = $Matches[1]
+    }
+}
+if (-not $extVersion) { Fail "Could not read PHP_SAPNWRFC_VERSION from $versionHeader" }
+Write-Host "Extension version: $extVersion"
+
+# ---------------------------------------------------------------------------
+# Discover PHP variants from .\php\*.zip
+# ---------------------------------------------------------------------------
+Step "Discovering PHP variants"
+
+$phpZipDir = Join-Path $PSScriptRoot "php"
+$phpZips   = @(Get-ChildItem -Path $phpZipDir -Filter "php-*.zip" -ErrorAction SilentlyContinue)
+
+if ($phpZips.Count -eq 0) { Fail "No PHP zip files found in $phpZipDir" }
+
+$variants = @()
+foreach ($zip in $phpZips) {
+    # Skip devel packages and the SDK zip — consumed separately
+    if ($zip.BaseName -match '-devel-') { continue }
+    if ($zip.BaseName -match '^php-sdk-binary-tools-') { continue }
+
+    # php-{ver}[-nts]-Win32-{toolset}-{arch}
+    if ($zip.BaseName -match '^php-(\d+\.\d+\.\d+)(-nts)?-Win32-(vs\d+)-(x64|x86)$') {
+        $isNts = $Matches[2] -eq '-nts'
+        $variants += [PSCustomObject]@{
+            ZipPath      = $zip.FullName
+            Version      = $Matches[1]
+            IsNts        = $isNts
+            Toolset      = $Matches[3]   # toolset in the zip filename — used for devel pack lookup
+            BuildToolset = $Matches[3]   # toolset used for building — may be overridden by -Toolset
+            Arch         = $Matches[4]
+            Label        = if ($isNts) { 'NTS' } else { 'TS' }
+        }
+        Write-Host "  Found: PHP $($Matches[1]) $(if ($isNts) {'NTS'} else {'TS'}) [$($Matches[3])-$($Matches[4])]"
+    } else {
+        Write-Warning "Skipping unrecognized zip: $($zip.Name)"
+    }
+}
+
+if ($variants.Count -eq 0) { Fail "No recognizable PHP zips found in $phpZipDir" }
+
+# --- Report installed Visual Studio ---
+$vsInfo          = Get-VsToolset
+$detectedToolset = if ($vsInfo) { $vsInfo.Toolset } else { $null }
+if ($vsInfo) {
+    Write-Host "  Installed VS  : $($vsInfo.Toolset) at $($vsInfo.InstallPath)"
+} else {
+    Write-Warning "vswhere not found - cannot detect installed Visual Studio"
+}
+
+# MSVC minor-version ranges per toolset generation (second component of "14.XX.YYYYY"):
+#   vs16 = VS 2019  = MSVC 14.20-14.29
+#   vs17 = VS 2022  = MSVC 14.30-14.43  (17.0 shipped 14.30, 17.13 shipped 14.43)
+#   vs18 = VS 2026  = MSVC 14.44+
+$ToolsetMinorRange = @{
+    'vs16' = @{ Min = 20; Max = 29 }
+    'vs17' = @{ Min = 30; Max = 43 }
+    'vs18' = @{ Min = 44; Max = 99 }
+}
+
+# --- Apply -Toolset override ---
+# -Toolset overrides the compiler (BuildToolset) but not the devel pack lookup (Toolset).
+if ($Toolset) {
+    Write-Host "  Toolset override: $Toolset (from -Toolset parameter) - devel pack lookup still uses zip toolset"
+    $variants = @($variants | ForEach-Object { $_.BuildToolset = $Toolset; $_ })
+}
+
+# ---------------------------------------------------------------------------
+# Extract SAP NW RFC SDK from .\sap\*.zip
+# ---------------------------------------------------------------------------
+Step "Preparing SAP NW RFC SDK"
+
+$sapZipDir = Join-Path $PSScriptRoot "sap"
+$sapZip    = Get-ChildItem -Path $sapZipDir -Filter "*.zip" -ErrorAction SilentlyContinue |
+             Select-Object -First 1
+
+if (-not $sapZip) { Fail "No SAP NW RFC SDK zip found in $sapZipDir" }
+
+New-Item -ItemType Directory -Force $WorkspaceDir | Out-Null
+$NwRfcSdkDir = Join-Path $WorkspaceDir "nwrfcsdk"
+
+if (-not (Test-Path $NwRfcSdkDir)) {
+    Write-Host "  Extracting $($sapZip.Name) ..."
+    $sapTemp = Join-Path $WorkspaceDir "_sap_tmp"
+    Expand-Archive -Path $sapZip.FullName -DestinationPath $sapTemp -Force
+
+    # SAP zips sometimes nest the sdk inside a nwrfcsdk sub-folder
+    $nested = Get-ChildItem -Path $sapTemp -Filter "nwrfcsdk" -Recurse -Directory |
+              Select-Object -First 1
+    if ($nested) {
+        Move-Item $nested.FullName $NwRfcSdkDir
+        Remove-Item $sapTemp -Recurse -Force -ErrorAction SilentlyContinue
+    } else {
+        Move-Item $sapTemp $NwRfcSdkDir
+    }
+} else {
+    Write-Host "  Already present: $NwRfcSdkDir"
+}
+
+if (-not (Test-Path (Join-Path $NwRfcSdkDir "include"))) {
+    Fail "SAP NW RFC SDK 'include' dir not found under $NwRfcSdkDir - check zip structure"
+}
+
+Write-Host "  SAP NW RFC SDK: $NwRfcSdkDir"
+
+# Read SDK version from sapnwrfc.dll file metadata
+$sdkDll = Join-Path $NwRfcSdkDir "lib\sapnwrfc.dll"
+if (-not (Test-Path $sdkDll)) { Fail "sapnwrfc.dll not found under $NwRfcSdkDir\lib — check SDK zip structure" }
+$vi = (Get-Item $sdkDll).VersionInfo
+$sdkVersion = "$($vi.FileMajorPart).$($vi.FileMinorPart).$($vi.FileBuildPart)"
+Write-Host "  SAP NW RFC SDK version: $sdkVersion"
+
+# ---------------------------------------------------------------------------
+# PHP SDK binary tools — extract from .\php\php-sdk-binary-tools-*.zip
+# ---------------------------------------------------------------------------
+Step "Preparing PHP SDK binary tools"
+
+$phpSdkZip = Get-ChildItem -Path $phpZipDir -Filter "php-sdk-binary-tools-*.zip" -ErrorAction SilentlyContinue |
+             Select-Object -First 1
+
+if (-not $phpSdkZip) {
+    Fail "PHP SDK zip not found in $phpZipDir`n  Place php-sdk-binary-tools-*.zip there (download from github.com/php/php-sdk-binary-tools/releases) and re-run."
+}
+
+if (-not (Test-Path $PhpSdkDir)) {
+    Write-Host "  Extracting $($phpSdkZip.Name) ..."
+    $sdkTemp = Join-Path $WorkspaceDir "_sdk_tmp"
+    Expand-Archive -Path $phpSdkZip.FullName -DestinationPath $sdkTemp -Force
+
+    # GitHub release archives have a single top-level folder; move its contents up
+    $topLevel = Get-ChildItem -Path $sdkTemp -Directory | Select-Object -First 1
+    if ($topLevel) {
+        Move-Item $topLevel.FullName $PhpSdkDir
+        Remove-Item $sdkTemp -Recurse -Force -ErrorAction SilentlyContinue
+    } else {
+        Move-Item $sdkTemp $PhpSdkDir
+    }
+    Write-Host "  PHP SDK: $PhpSdkDir"
+} else {
+    Write-Host "  PHP SDK already at $PhpSdkDir"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run build commands via phpsdk -t inner.bat so the VS environment
+# is fully configured before phpize/configure/nmake execute.
+# ---------------------------------------------------------------------------
+function Invoke-BuildBat([string]$content, [string]$PhpSdkBat, [string]$VsEnvLines = "") {
+    $innerBat = Join-Path $env:TEMP "sapnwrfc_inner_$([System.IO.Path]::GetRandomFileName().Replace('.',''))_.bat"
+    $outerBat = Join-Path $env:TEMP "sapnwrfc_outer_$([System.IO.Path]::GetRandomFileName().Replace('.',''))_.bat"
+    $exitFile = Join-Path $env:TEMP "sapnwrfc_exit_$([System.IO.Path]::GetRandomFileName().Replace('.',''))_.txt"
+
+    # Inner bat: wrap content in a :build subroutine so that "|| exit /b 1" guards
+    # inside the content exit the subroutine but not the outer bat, ensuring the
+    # echo line always runs and the exit file is always written.
+    $innerBatContent = "@echo off`r`ncall :build`r`necho %ERRORLEVEL% > `"$exitFile`"`r`nexit /b 0`r`n`r`n:build`r`n" + $content
+    Set-Content -Path $innerBat -Value $innerBatContent -Encoding ASCII
+
+    # Outer bat: sets up VS env then runs the inner bat.
+    # $VsEnvLines: when set, VS env is established via vcvarsall directly (cross-toolset builds).
+    # Otherwise phpsdk bat is used (sets up VS env + php-sdk paths in one shot).
+    if ($VsEnvLines) {
+        Set-Content -Path $outerBat -Value ("@echo off`r`n" + $VsEnvLines + "`r`ncall `"$innerBat`"") -Encoding ASCII
+    } else {
+        Set-Content -Path $outerBat -Value "@echo off`r`ncall `"$PhpSdkBat`" -t `"$innerBat`"" -Encoding ASCII
+    }
+
+    try {
+        & cmd.exe /c "`"$outerBat`"" | Out-Host
+        if (-not (Test-Path $exitFile)) {
+            Fail "Build batch did not complete — VS environment setup likely failed (vcvarsall or phpsdk_setvars). Check output above for details."
+        }
+        return [int](Get-Content $exitFile).Trim()
+    } finally {
+        Remove-Item $innerBat -Force -ErrorAction SilentlyContinue
+        Remove-Item $outerBat -Force -ErrorAction SilentlyContinue
+        Remove-Item $exitFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Build each variant
+# ---------------------------------------------------------------------------
+$results = [System.Collections.Generic.List[object]]::new()
+
+foreach ($v in $variants) {
+    $buildLabel = if ($v.BuildToolset -ne $v.Toolset) { "$($v.Toolset)->$($v.BuildToolset)" } else { $v.Toolset }
+    Step "Building PHP $($v.Version) $($v.Label) ($buildLabel-$($v.Arch))"
+
+    # --- PHP SDK batch for this toolset ---
+    $phpsdk_bat = Join-Path $PhpSdkDir "phpsdk-$($v.BuildToolset)-$($v.Arch).bat"
+    if (-not (Test-Path $phpsdk_bat)) {
+        Write-Warning "PHP SDK batch not found: $phpsdk_bat"
+        $available = @(Get-ChildItem -Path $PhpSdkDir -Filter "phpsdk-vs*-$($v.Arch).bat" -ErrorAction SilentlyContinue)
+        if ($available) {
+            $names = ($available | ForEach-Object { $_.BaseName -replace "^phpsdk-|-$($v.Arch)$" }) -join ', '
+            Write-Warning "Available toolsets in PHP SDK: $names - use -Toolset <value> to select one"
+        } else {
+            Write-Warning "No phpsdk-vs*-$($v.Arch).bat found in $PhpSdkDir"
+        }
+        $results.Add([PSCustomObject]@{ Variant = $v; Success = $false; Dll = $null })
+        continue
+    }
+
+    # --- Extract PHP binary (provides php.exe for --with-prefix) ---
+    $phpDir = Join-Path $WorkspaceDir "php-$($v.Version)-$($v.Label.ToLower())-$($v.Arch)"
+    if (-not (Test-Path $phpDir)) {
+        Write-Host "  Extracting PHP $($v.Label) binary ..."
+        Expand-Archive -Path $v.ZipPath -DestinationPath $phpDir
+    } else {
+        Write-Host "  PHP $($v.Label) binary already at $phpDir"
+    }
+
+    # --- Locate PHP devel package (provides phpize + headers) ---
+    $ntsPart  = if ($v.IsNts) { '-nts' } else { '' }
+    $develPkg = "php-devel-pack-$($v.Version)$($ntsPart)-Win32-$($v.Toolset)-$($v.Arch)"
+    $develDir = Join-Path $WorkspaceDir $develPkg
+    $localDevelZip = Join-Path $phpZipDir "$develPkg.zip"
+
+    if (-not (Test-Path $localDevelZip)) {
+        Fail "Devel package not found: $localDevelZip`n  Place $develPkg.zip in $phpZipDir and re-run."
+    }
+
+    if (-not (Test-Path $develDir)) {
+        Write-Host "  Extracting $develPkg.zip ..."
+        $develTemp = Join-Path $WorkspaceDir "_devel_tmp_$($v.Version)_$($v.Label)"
+        Expand-Archive -Path $localDevelZip -DestinationPath $develTemp
+        $topDir = Get-ChildItem -Path $develTemp -Directory | Select-Object -First 1
+        if ($topDir -and -not (Get-ChildItem -Path $develTemp -File)) {
+            Move-Item $topDir.FullName $develDir
+            Remove-Item $develTemp -Recurse -Force -ErrorAction SilentlyContinue
+        } else {
+            Move-Item $develTemp $develDir
+        }
+    } else {
+        Write-Host "  Devel package already extracted at $develDir"
+    }
+
+    # --- Build ---
+    # phpsdk -t sets up the full VS environment; inner bat only needs the devel pack on PATH
+    $buildBat = @"
+@echo off
+set "PATH=%PATH%;$develDir"
+cd /d "$ExtSourceDir"
+call phpize || exit /b 1
+call "$ExtSourceDir\configure.bat" --with-prefix="$phpDir" --with-sapnwrfc="$NwRfcSdkDir" || exit /b 1
+nmake || exit /b 1
+"@
+
+    # --- VS environment setup ---
+    # When BuildToolset matches the installed VS, use the phpsdk bat (sets up everything).
+    # When they differ (e.g. vs17 ZIP on VS 2026), call vcvarsall directly with -vcvars_ver
+    # so the correct MSVC toolset is selected. Fails if that toolset is not installed.
+    $vsEnvLines = ""
+    if ($v.BuildToolset -ne $detectedToolset -and $vsInfo) {
+        $range = $ToolsetMinorRange[$v.BuildToolset]
+        if (-not $range) {
+            Fail "No minor-version range defined for toolset '$($v.BuildToolset)' - add it to `$ToolsetMinorRange"
+        }
+        # Find the latest installed MSVC dir that falls in the expected minor range
+        $msvcRoot     = Join-Path $vsInfo.InstallPath "VC\Tools\MSVC"
+        $toolsetDir   = Get-ChildItem $msvcRoot -Directory -ErrorAction SilentlyContinue |
+                        Where-Object {
+                            $minor = [int](($_.Name -split '\.')[1])
+                            $minor -ge $range.Min -and $minor -le $range.Max
+                        } |
+                        Sort-Object Name -Descending |
+                        Select-Object -First 1
+        if (-not $toolsetDir) {
+            Fail ("MSVC toolset $($v.BuildToolset) (minor $($range.Min)-$($range.Max)) not found in $msvcRoot.`n" +
+                  "  Install it via VS Installer -> Modify -> Individual Components`n" +
+                  "  -> 'MSVC v1XX - VS 20XX C++ x64/x86 build tools (Latest)'")
+        }
+        # Use "major.minor" as -vcvars_ver (e.g. "14.43" selects 14.43.xxxxx)
+        $parts      = $toolsetDir.Name -split '\.'
+        $vcvarsVer  = "$($parts[0]).$($parts[1])"
+        $vcvarsall  = Join-Path $vsInfo.InstallPath "VC\Auxiliary\Build\vcvarsall.bat"
+        $vcvarsArch = if ($v.Arch -eq 'x64') { 'amd64' } else { 'x86' }
+        $vsEnvLines = "call `"$vcvarsall`" $vcvarsArch -vcvars_ver=$vcvarsVer`r`n" +
+                      "if %ERRORLEVEL% neq 0 exit /b 1`r`n" +
+                      "call `"$PhpSdkDir\bin\phpsdk_setvars.bat`"`r`n" +
+                      "if %ERRORLEVEL% neq 0 exit /b 1"
+        Write-Host "  VS env: vcvarsall -vcvars_ver=$vcvarsVer ($($toolsetDir.Name)) zip=$($v.Toolset) host=$detectedToolset"
+    }
+
+    $buildExit = Invoke-BuildBat $buildBat $phpsdk_bat $vsEnvLines
+    if ($buildExit -ne 0) {
+        Write-Warning "Build FAILED for PHP $($v.Label) (exit $buildExit)"
+        $results.Add([PSCustomObject]@{ Variant = $v; Success = $false; Dll = $null })
+        continue
+    }
+
+    # TS builds output to Release_TS, NTS to Release
+    $releaseDir  = if ($v.IsNts) { "$($v.Arch)\Release" } else { "$($v.Arch)\Release_TS" }
+    $builtDll    = Join-Path $ExtSourceDir "$releaseDir\php_sapnwrfc.dll"
+    $dllName     = "php_sapnwrfc-$extVersion+php.$($v.Version)-$($v.Label.ToLower())-$($v.Toolset)-$($v.Arch).sdk.$sdkVersion.dll"
+    $destDir     = $OutputDir
+    $destDll     = Join-Path $destDir $dllName
+
+    if (Test-Path $builtDll) {
+        New-Item -ItemType Directory -Force $destDir | Out-Null
+        Copy-Item -Path $builtDll -Destination $destDll -Force
+        Write-Host "  Built ($($v.Label)): $destDll" -ForegroundColor Green
+        $results.Add([PSCustomObject]@{ Variant = $v; Success = $true; Dll = $destDll })
+    } else {
+        Write-Warning "DLL not found at expected path: $builtDll"
+        $results.Add([PSCustomObject]@{ Variant = $v; Success = $false; Dll = $null })
+    }
+
+    # --- Optional tests ---
+    if ($RunTests) {
+        Step "Running tests for PHP $($v.Label)"
+
+        $testBat = @"
+@echo off
+set "PATH=%PATH%;$develDir;$NwRfcSdkDir\lib"
+cd /d "$ExtSourceDir"
+nmake test || exit /b 1
+"@
+        $testExit = Invoke-BuildBat $testBat $phpsdk_bat $vsEnvLines
+        if ($testExit -ne 0) {
+            Write-Warning "Tests reported failures for $($v.Label) (exit $testExit)"
+        } else {
+            Write-Host "  Tests passed ($($v.Label))" -ForegroundColor Green
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+Step "Summary"
+foreach ($r in $results) {
+    $tag = "[$($r.Variant.Label)]"
+    if ($r.Success -and $r.Dll) {
+        Write-Host "  $tag OK  ->  $($r.Dll)" -ForegroundColor Green
+    } else {
+        Write-Host "  $tag FAILED" -ForegroundColor Red
+    }
+}
+
+$anyOk = $results | Where-Object { $_.Success -and $_.Dll }
+if ($anyOk) {
+    Write-Host ""
+    Write-Host "  Next steps:" -ForegroundColor Cyan
+    Write-Host "    1. Copy the DLL(s) from $OutputDir\ to your PHP ext\ directory"
+    Write-Host "    2. Add  extension=sapnwrfc  to php.ini"
+    Write-Host "    3. Ensure $NwRfcSdkDir\lib is on PATH so PHP can load the SAP DLLs"
+}


### PR DESCRIPTION
## Summary

Adds a self-contained PowerShell build script (`build/build-windows.ps1`) and accompanying documentation (`build/build-windows.md`) for building the extension on Windows across multiple PHP variants.

- Discovers all PHP variants (TS/NTS, version, toolset, arch) from zip files placed in `build\php\` — no git clone or internet access needed
- Auto-detects installed Visual Studio via `vswhere`; handles cross-toolset builds (e.g. vs16/vs17 PHP zips on a VS 2026 host) via `vcvarsall -vcvars_ver`
- Produces versioned DLL filenames encoding extension, PHP, and SDK versions: `php_sapnwrfc-{ext}+php.{php}-{ts|nts}-{toolset}-{arch}.sdk.{sdk}.dll`
- All DLLs collected flat in `build\output\`
- Optional `-RunTests` flag runs `nmake test` after each build using the same MSVC environment as the build step (correct for cross-toolset)

Also updates `.gitignore`: replaces the blanket `build/` exclusion with specific subdirectory entries (`output/`, `php/`, `sap/`, `workspace/`) so the script and documentation are tracked, and adds Windows build artefacts (`x64/`, `x86/`, `configure.bat`, `*.log`) to the ignore list.

## Test plan
- [ ] Place PHP binary + devel zips and SAP NW RFC SDK zip in the expected directories
- [ ] Run `.\build-windows.ps1` on a VS 2026 machine with vs16 and vs17 components installed
- [ ] Verify each built DLL loads in PHP (`php -m | findstr sapnwrfc`)
- [ ] Run with `-RunTests` and confirm test output is reported per variant
- [ ] Confirm `build\output\`, `build\php\`, `build\sap\`, `build\workspace\` are excluded from `git status`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)